### PR TITLE
Enhancement fast stopping

### DIFF
--- a/src/container/core.jl
+++ b/src/container/core.jl
@@ -78,7 +78,6 @@ Shut down the container. It is always necessary to call it for freeing bound res
 function shutdown(container::Container)
     container.shutdown = true
     close(container.protocol)
-    Threads.@spawn Base.throwto(container.loop, InterruptException())
 
     for task in container.tasks
         wait(task)
@@ -108,7 +107,7 @@ The actually used aid will be returned.
 function register(
     container::Container,
     agent::Agent,
-    suggested_aid::Union{String,Nothing} = nothing,
+    suggested_aid::Union{String,Nothing}=nothing,
 )
     actual_aid::String = "$AGENT_PREFIX$(container.agent_counter)"
     if isnothing(suggested_aid) && haskey(container.agents, suggested_aid)
@@ -159,8 +158,8 @@ function send_message(
     container::Container,
     content::Any,
     receiver_id::String,
-    receiver_addr::Any = nothing,
-    sender_id::Union{Nothing,String} = nothing;
+    receiver_addr::Any=nothing,
+    sender_id::Union{Nothing,String}=nothing;
     kwargs...,
 )
 

--- a/src/container/tcp.jl
+++ b/src/container/tcp.jl
@@ -31,7 +31,7 @@ end
 @with_kw mutable struct TCPProtocol <: Protocol{InetAddr}
     address::InetAddr
     server::Union{Nothing,TCPServer} = nothing
-    pool::TCPConnectionPool = TCPConnectionPool(keep_alive_time_ms = 100000)
+    pool::TCPConnectionPool = TCPConnectionPool(keep_alive_time_ms=100000)
 end
 
 function close(pool::TCPConnectionPool)
@@ -55,8 +55,8 @@ function acquire_tcp_connection(tcp_pool::TCPConnectionPool, key::InetAddr)::TCP
     connection, _ = acquire(
         tcp_pool.connections,
         key,
-        forcenew = false,
-        isvalid = c -> is_valid(c, tcp_pool.keep_alive_time_ms),
+        forcenew=false,
+        isvalid=c -> is_valid(c, tcp_pool.keep_alive_time_ms),
     ) do
         return (connect(key.host, key.port), Dates.now())
     end
@@ -160,7 +160,7 @@ function init(protocol::TCPProtocol, stop_check::Function, data_handler::Functio
                     )
                 end
             catch err
-                if isa(err, InterruptException)
+                if isa(err, InterruptException) || isa(err, Base.IOError)
                     # nothing
                 else
                     @error "Caught an unexpected error in listen" exception =
@@ -184,4 +184,5 @@ Release all tcp resources
 """
 function close(protocol::TCPProtocol)
     close(protocol.pool)
+    close(protocol.server)
 end

--- a/src/util/scheduling.jl
+++ b/src/util/scheduling.jl
@@ -37,7 +37,7 @@ struct PeriodicTaskData <: TaskData
     timer::Timer
 
     function PeriodicTaskData(interval_s::Float64)
-        return new(Timer(0; interval_s))
+        return new(Timer(interval_s; interval=interval_s))
     end
 end
 
@@ -123,7 +123,7 @@ function wait_for_all_tasks(scheduler::Scheduler)
         try
             wait(task)
         catch err
-            if isa(task.result, InterruptException)
+            if isa(task.result, InterruptException) || isa(task.result, EOFError)
                 # ignore, task has been interrupted by the scheduler
             else
                 @error "An error occurred while waiting for $task" exception =


### PR DESCRIPTION
Using closeable resources for stopping tasks. This improves the shutdown speed by the waiting times of the periodic schedules and ensures a clean scheduler state in multi-threaded environments