### PR TITLE
Fix agent role macro typevar #49

### DIFF
--- a/src/agent/core.jl
+++ b/src/agent/core.jl
@@ -59,7 +59,7 @@ AGENT_BASELINE_DEFAULTS::Vector = [
     () -> AgentRoleHandler(Vector(), Vector(), Vector(), Dict(), Dict()),
     () -> Scheduler(),
     () -> nothing,
-    () -> Dict(),
+    () -> Dict{String,Tuple}(),
 ]
 
 """
@@ -94,7 +94,11 @@ my_agent = MyAgent("own value")
 ```
 """
 macro agent(struct_def)
-    struct_name = struct_def.args[2]
+    struct_head = struct_def.args[2]
+    struct_name = struct_head
+    if typeof(struct_name) != Symbol
+        struct_name = struct_head.args[1]
+    end
     struct_fields = struct_def.args[3].args
 
     # Add the agents baseline fields
@@ -106,14 +110,14 @@ macro agent(struct_def)
     new_struct_def = Expr(
         :struct,
         true,
-        Expr(:(<:), struct_name, :(Agent)),
+        Expr(:(<:), struct_head, :(Agent)),
         Expr(:block, struct_fields...),
     )
 
     # Create a constructor, which will assign 'nothing' to all baseline fields, therefore requires you just to call it with the your fields
     # f.e. @agent MyMagent own_field::String end, can be constructed using MyAgent("MyOwnValueFor own_field").
     new_fields = [
-        field for field in struct_fields[2+length(AGENT_BASELINE_FIELDS):end] if
+        field.args[1] for field in struct_fields[2+length(AGENT_BASELINE_FIELDS):end] if
         typeof(field) != LineNumberNode
     ]
     default_constructor_def = Expr(

--- a/test/agent_tests.jl
+++ b/test/agent_tests.jl
@@ -296,3 +296,22 @@ end
     wait(Threads.@spawn shutdown(c1))
     wait(Threads.@spawn shutdown(c2))
 end
+
+@agent struct MyAgentVar{T}
+    counter::T
+end
+@agent struct MyAgentVarVar{T<:AbstractFloat,D}
+    other::D
+    the_float::T
+end
+
+@testset "TestTypedAgents" begin
+    agent_var = MyAgentVar(1)
+
+    @test agent_var.counter == 1
+    
+    agent_var_var = MyAgentVarVar(2, 3.3)
+
+    @test agent_var_var.other == 2
+    @test agent_var_var.the_float == 3.3
+end

--- a/test/role_tests.jl
+++ b/test/role_tests.jl
@@ -149,3 +149,12 @@ end
     @test addr.aid == aid(agent)
     @test isnothing(addr.address)
 end
+
+@role struct MyRoleVar{T}
+    counter::T
+end
+
+@testset "TestTypedRoles" begin
+    role_var = MyRoleVar(1)
+    @test role_var.counter == 1 
+end


### PR DESCRIPTION
Fixing #49.
* The actual reason was that the default constructor generated by the macro was malformed due to the type var