### PR TITLE
add graphs api forwarding to topology

### DIFF
--- a/docs/src/topology.md
+++ b/docs/src/topology.md
@@ -49,6 +49,24 @@ end
 topology_neighbors(container[1])
 ```
 
+Functions that are defined on `Graphs.jl`graphs have been extended with methods for topologies so the following calls will resolve normally. 
+Note that this requires `using Graphs` as well as `using Mango` to resolve correctly:
+```julia
+using Graphs, Mango
+topology = complete_topology(5)
+
+edges(topology) # SimpleEdgeIter 10
+edgetype(topology) # Graphs.SimpleGraphs.SimpleEdge{Int64}
+has_edge(topology, 1, 2) # true
+has_vertex(topology, 1) # true
+inneighbors(topology, 2) # [1, 3, 4, 5]
+outneighbors(topology, 2) # [1, 3, 4, 5]
+is_directed(topology) # false
+ne(topology) # 10
+nv(topology) # 5
+vertices(topology) # [1, 2, 3, 4, 5]
+```
+
 # Using the topology
 
 At this point we know how to create topologies and how to populate them. To actually use them, the function [`topology_neighbors`](@ref) exists. The function returns a vector of AgentAddress objects, which represent all other agents in the neighborhood of `agent`.

--- a/src/world/topology.jl
+++ b/src/world/topology.jl
@@ -273,3 +273,44 @@ end
 function topology_neighbors(role::Role, state::State=NORMAL)::Vector{AgentAddress}
     return neighbors(service_of_type(role.context.agent, TopologyService, TopologyService()), state)
 end
+
+# Graphs API calls forwarded to Topology
+function Graphs.edges(topology::Topology)
+    return edges(topology.graph)
+end
+
+function Graphs.edgetype(topology::Topology)
+    return edgetype(topology.graph)
+end
+
+function Graphs.vertices(topology::Topology)
+    return vertices(topology.graph)
+end
+
+function Graphs.has_edge(topology::Topology, s::Any, d::Any)
+    return has_edge(topology.graph, s, d)
+end
+
+function Graphs.has_vertex(topology::Topology, v::Any)
+    return has_vertex(topology.graph, v)
+end
+
+function Graphs.inneighbors(topology::Topology, v::Any)
+    return inneighbors(topology.graph, v)
+end
+
+function Graphs.outneighbors(topology::Topology, v::Any)
+    return outneighbors(topology.graph, v)
+end
+
+function Graphs.is_directed(topology::Topology)
+    return is_directed(topology.graph)
+end
+
+function Graphs.ne(topology::Topology)
+    return ne(topology.graph)
+end
+
+function Graphs.nv(topology::Topology)
+    return nv(topology.graph)
+end

--- a/test/topology_tests.jl
+++ b/test/topology_tests.jl
@@ -207,3 +207,19 @@ end
 
     @test length(topology_neighbors(container["agent0"])) == 2
 end
+
+@testset "TestTopologyGraphAPI" begin
+    n_nodes = 5
+    topology = complete_topology(n_nodes)
+    @test length(collect(edges(topology))) == (n_nodes^2 - n_nodes) / 2
+    @test collect(edges(topology))[1] ∈ collect(edges(topology))
+    @test edgetype(topology) == Graphs.SimpleGraphs.SimpleEdge{Int64}
+    @test has_edge(topology, 1, 2)
+    @test has_vertex(topology, 1)
+    @test inneighbors(topology, 2) == [1, 3, 4, 5]
+    @test outneighbors(topology, 2) == [1, 3, 4, 5]
+    @test !is_directed(topology)
+    @test ne(topology) == (n_nodes^2 - n_nodes) / 2
+    @test nv(topology) == 5
+    @test collect(vertices(topology)) == [1, 2, 3, 4, 5]
+end


### PR DESCRIPTION
Added graphs APIs. 
Did not include `Graphs.src` and `Graphs.dst` because those only make sense on edges so no new calls are necessary.

closes #63 